### PR TITLE
Fixed brightness controls

### DIFF
--- a/buttons.py
+++ b/buttons.py
@@ -445,7 +445,7 @@ class ViscaDeck:
         self._driveActive = True
 
     def _moveCameraZoomPressed_callback(self, pressed: bool, key: int, dir: str):
-        speed = [1, 3, 7][self._camDriveSpeed]
+        speed = [1, 4, 7][self._camDriveSpeed]
         if not pressed:
             if self._driveActive:
                 speed = 0

--- a/obs-viscadeck-main.py
+++ b/obs-viscadeck-main.py
@@ -180,6 +180,9 @@ def configureMain():
             newCam = ptz.Camera(camera.ip, camera.port, camera.channel, camera.name, len(cameras))
             newCam.sceneName = "" # add property to hold scene name
             cameras.append(newCam)
+            for command in camera.BootCommands:
+                print(f'sending command "{command.command}" to {camera.name}...')
+                newCam.sendCommand(command.packet)
         print(f"{len(cameras)} cameras loaded")
     except AttributeError:
         return False

--- a/ptz.py
+++ b/ptz.py
@@ -4,7 +4,13 @@ import re
 # from urllib import response # TODO is this supposed to be here or did it get auto added inadvertently???
 from __time import curMillis
 
+SHUTTER_MIN = 1
+SHUTTER_MAX = 17
+APERTURE_MIN = 0
+APERTURE_MAX = 12
+
 class Camera:
+
 
     def __init__(self, ip, port, channel, name, id) -> None:
         self.name = name
@@ -15,6 +21,8 @@ class Camera:
         self._pan = -1
         self._tilt = -1
         self._zoom = -1
+        self._shutter = -1
+        self._aperture = -1
         self._awaiting = [] # tuples of (awaited message, handler) [can't be a dict since duplicates are allowed]
         self._sparePackets = [] # received packets that weren't being awaited at the time
 
@@ -40,9 +48,38 @@ class Camera:
         #print(f'finishing with {len(self._awaiting)} awaited packets remaining')
         return True
 
+    def setAperture(self, a):
+        moveMsg = f'8{self._channel:01X}01044B00000{(a >> 4) & 0xF:01X}0{a & 0xF:01X}FF'
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect((self._ip, self._port))
+        if not self._sendAndAck(sock, bytes.fromhex(moveMsg), 3, 2000):
+            return False
+        self._awaiting.append((re.compile(r"905[\da-f]ff$"), None)) # completion message
+        if not self._clearAwaiting(sock, 10000):
+            return False
+        sock.close()
+        return True
+
+    def setShutter(self, s):
+        moveMsg = f'8{self._channel:01X}01044A00000{(s >> 4) & 0xF:01X}0{s & 0xF:01X}FF'
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect((self._ip, self._port))
+        if not self._sendAndAck(sock, bytes.fromhex(moveMsg), 3, 2000):
+            return False
+        self._awaiting.append((re.compile(r"905[\da-f]ff$"), None)) # completion message
+        if not self._clearAwaiting(sock, 10000):
+            return False
+        sock.close()
+        return True
+
     def getPosition(self):
         self._updatePosition()
         return (self._pan, self._tilt, self._zoom)
+    
+    def getExposure(self):
+        self._updateAperture()
+        self._updateShutter()
+        return (self._aperture, self._shutter)
     
     def autofocus(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -96,37 +133,64 @@ class Camera:
     def driveShutter(self, up: bool):
         print('SHUTTER ' + ('UP' if up else 'DOWN'))
         modeStr = f'8{self._channel:01X}01043903FF'
-        driveStr = f'8{self._channel:01X}01040A0{"2" if up else "3"}FF'
+        # driveStr = f'8{self._channel:01X}01040A0{"2" if up else "3"}FF'
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.connect((self._ip, self._port))
         # have to first make sure exposure mode is set to manual
         # TODO make this done when shutter is selected from the deck, not every time the adjust button is pressed
-        if not self._sendAndAck(sock, bytes.fromhex(modeStr), 3, 2000):
-            return False
-        if not self._sendAndAck(sock, bytes.fromhex(driveStr), 3, 2000):
-            return False
-        self._awaiting += [(re.compile(r"905[\da-f]ff$"), None)] # completion message
-        #print(f'awaiting {len(self._awaiting)} packets...')
-        if not self._clearAwaiting(sock, 2000):
-            return False
+        # if not self._sendAndAck(sock, bytes.fromhex(modeStr), 3, 2000):
+        #     return False
+        sock.close()
+        
+        # if not self._sendAndAck(sock, bytes.fromhex(driveStr), 3, 2000):
+        #     return False
+        # self._awaiting += [(re.compile(r"905[\da-f]ff$"), None)] # completion message
+        # #print(f'awaiting {len(self._awaiting)} packets...')
+        # if not self._clearAwaiting(sock, 2000):
+        #     return False
+        # return True
+    
+        # the PTZOptics cameras are stupid and buggy and love to fight the exposure up/down commands by immediately
+        # readjusting the values so instead we have to inquire the current exposure values and then manually set
+        # the incremented values directly
+        
+        self._updateShutter()
+        newShutter = self._shutter + (1 if up else -1)
+        if newShutter >= SHUTTER_MIN and newShutter <= SHUTTER_MAX:
+            self.setShutter(newShutter)
         return True
     
     def driveAperture(self, up: bool):
         print('APERTURE ' + ('UP' if up else 'DOWN'))
         modeStr = f'8{self._channel:01X}01043903FF'
-        driveStr = f'8{self._channel:01X}01040B0{"2" if up else "3"}FF'
+        # driveStr = f'8{self._channel:01X}01040B0{"2" if up else "3"}FF'
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.connect((self._ip, self._port))
         # have to first make sure exposure mode is set to manual
         # TODO make this done when aperture is selected from the deck, not every time the adjust button is pressed
-        if not self._sendAndAck(sock, bytes.fromhex(modeStr), 3, 2000):
-            return False
-        if not self._sendAndAck(sock, bytes.fromhex(driveStr), 3, 2000):
-            return False
-        self._awaiting += [(re.compile(r"905[\da-f]ff$"), None)] # completion message
+        # !!TODO HIGH PRIORITY!! must move this out of here, it seems to sometimes be causing fighting even with the direct-set method below
+        #                        maybe just get rid of brightness control and put it in initial camera setup requested in issue #21
+        # if not self._sendAndAck(sock, bytes.fromhex(modeStr), 3, 2000):
+        #     return False
+        sock.close()
+
+        # if not self._sendAndAck(sock, bytes.fromhex(driveStr), 3, 2000):
+        #     return False
+        # self._awaiting += [(re.compile(r"905[\da-f]ff$"), None)] # completion message
         #print(f'awaiting {len(self._awaiting)} packets...')
-        if not self._clearAwaiting(sock, 2000):
-            return False
+        # if not self._clearAwaiting(sock, 2000):
+        #     return False
+
+        # stupid buggy cameras, gotta do it manually like with shutter
+
+        self._updateAperture()
+        newAperture = self._aperture + (1 if up else -1)
+        if newAperture >= APERTURE_MIN and newAperture <= APERTURE_MAX:
+            ts = curMillis()
+            # do a stupid pause?
+            # while curMillis() < ts + 5:
+            #     pass
+            self.setAperture(newAperture)
         return True
     
     def driveBrightness(self, up: bool):
@@ -170,12 +234,55 @@ class Camera:
         #print('responses received')
         sock.close()
 
+    def _updateAperture(self):
+        apertureInqMsg = f'8{self._channel}09044BFF'
+        # print(f'opening socket')
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect((self._ip, self._port))
+        # (apparently inquiry messages aren't ACK'ed)
+        # TODO change sendAndAck to optionally not require ACK but still make sure no NAK is received
+
+        # return messages are indistinguishable (seriously Sony?), must send one and wait for retrun before sending next
+        # print(f'sending shutter inquiry')
+        # sock.send(bytes.fromhex(shutterInqMsg)) # TODO temp, see above
+        # print(f'awaiting shutter response')
+        # self._awaiting.append((re.compile(r"9050(0[\da-f]){4}ff$"), self._unstuffShutter))
+        # self._clearAwaiting(sock, 5000)
+        # print(f'sending aperture inquiry')
+        sock.send(bytes.fromhex(apertureInqMsg)) # TODO temp, see above
+        # print(f'awaiting aperture response')
+        self._awaiting.append((re.compile(r"9050(0[\da-f]){4}ff$"), self._unstuffAperture))
+        self._clearAwaiting(sock, 5000)
+        sock.close()
+
+    def _updateShutter(self):
+        shutterInqMsg = f'8{self._channel}09044AFF'
+        # print(f'opening socket')
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect((self._ip, self._port))
+        # (apparently inquiry messages aren't ACK'ed)
+        # TODO change sendAndAck to optionally not require ACK but still make sure no NAK is received
+
+        # return messages are indistinguishable (seriously Sony?), must send one and wait for retrun before sending next
+        # print(f'sending shutter inquiry')
+        sock.send(bytes.fromhex(shutterInqMsg)) # TODO temp, see above
+        # print(f'awaiting shutter response')
+        self._awaiting.append((re.compile(r"9050(0[\da-f]){4}ff$"), self._unstuffShutter))
+        self._clearAwaiting(sock, 5000)
+        sock.close()
+
     def _unstuffZoom(self, packet):
         self._zoom = (0x0F & packet[2]) << 12 | (0x0F & packet[3]) << 8 | (0x0F & packet[4]) << 4 | (0xF & packet[5])
 
     def _unstuffPanTilt(self, packet):
         self._pan = (0x0F & packet[2]) << 12 | (0x0F & packet[3]) << 8 | (0x0F & packet[4]) << 4 | (0x0F & packet[5])
         self._tilt = (0x0F & packet[6]) << 12 | (0x0F & packet[7]) << 8 | (0x0F & packet[8]) << 4 | (0x0F & packet[9])
+
+    def _unstuffShutter(self, packet):
+        self._shutter = (0x0F & packet[4]) << 4 | (0x0F & packet[5])
+
+    def _unstuffAperture(self, packet):
+        self._aperture = (0x0F & packet[4]) << 4 | (0x0F & packet[5])
     
     def _waitForPacket(self, sock, timeout):
         ts = curMillis() + timeout
@@ -188,6 +295,7 @@ class Camera:
                 buf += data # TODO account for multiple messages strung together (so 0xFF is in the middle)
             if curMillis() > ts:
                 return None
+        # print(f'got packet: {buf[1:].hex()}')
         return buf[1:]
     
     def _sendAndAck(self, sock, msg, retries, timeout):
@@ -245,5 +353,6 @@ class Camera:
         return not len(self._awaiting)
 
 if __name__ == "__main__":
-    cam1 = Camera('192.168.10.11', 1259, 1, "CAMERA 1")
-    cam2 = Camera('192.168.10.12', 1259, 1, "CAMERA 2")
+    cam1 = Camera('192.168.10.11', 1259, 1, "CAMERA 1", 1)
+    cam2 = Camera('192.168.10.12', 1259, 1, "CAMERA 2", 2)
+    cam3 = Camera('192.168.10.13', 1259, 1, "CAMERA 2", 3)


### PR DESCRIPTION
Changed brightness controls to manually query cameras' current state and directly set new state instead of using state up/down commands which the cameras like to fight against or ignore.